### PR TITLE
Fix(i18n): Use DE lang for "Pickup location"

### DIFF
--- a/frontend/src/lang/booking-filter.ts
+++ b/frontend/src/lang/booking-filter.ts
@@ -11,7 +11,7 @@ const strings = new LocalizedStrings({
     DROP_OFF_LOCATION: "Drop-off location",
   },
   de: {
-    PICKUP_LOCATION: "Abholort",
+    PICK_UP_LOCATION: "Abholort",
     DROP_OFF_LOCATION: "Abgabeort",
   },
 });

--- a/frontend/src/lang/common.ts
+++ b/frontend/src/lang/common.ts
@@ -220,7 +220,7 @@ const strings = new LocalizedStrings({
     RESEND_ACTIVATION_LINK: "Kontoaktivierungslink erneut senden",
     ACTIVATION_EMAIL_SENT: "Aktivierungs-E-Mail gesendet.",
     EMAIL_NOT_VALID: "Ungültige E-Mail-Adresse",
-    PICKUP_LOCATION: "Abholort",
+    PICK_UP_LOCATION: "Abholort",
     DROP_OFF_LOCATION: "Rückgabeort",
     PHONE_NOT_VALID: "Ungültige Telefonnummer",
     ALL: "Alle",


### PR DESCRIPTION
This change fixes the German i18n value for "Pickup location" on the frontend home page.

There is a naming inconsistency between the frontend and backend/mobile variables, with the frontend using `PICK_UP_LOCATION`([1][frontend-booking-filter], [2][frontend-common]) and backend/mobile using `PICKUP_LOCATION` ([1][backend-booking-filter], [2][backend-common], [3][mobile-common]). This inconsistency is likely what resulted in the mix-up.

As a consequence of the misnamed variable in the frontend code, no value was being set for occurrences of `PICK_UP_LOCATION` in the DE language, resulting in the app falling back to a known value (in this case, FR).

### Before
![image](https://github.com/XiSZ/bookcars/assets/42326027/12b411ff-b6ab-4924-9001-3f59c106bef8)

### After
![image](https://github.com/XiSZ/bookcars/assets/42326027/e4c9ffe4-af8e-4515-9f92-c3dc30002944)

[frontend-booking-filter]:https://github.com/aelassas/bookcars/blob/85dfa2f79e7609d18c6fe962aa4c21e625bcbb8a/frontend/src/lang/booking-filter.ts#L10
[frontend-common]:https://github.com/aelassas/bookcars/blob/85dfa2f79e7609d18c6fe962aa4c21e625bcbb8a/frontend/src/lang/common.ts#L143

[backend-booking-filter]:https://github.com/aelassas/bookcars/blob/85dfa2f79e7609d18c6fe962aa4c21e625bcbb8a/backend/src/lang/booking-filter.ts#L10
[backend-common]:https://github.com/aelassas/bookcars/blob/85dfa2f79e7609d18c6fe962aa4c21e625bcbb8a/backend/src/lang/common.ts#L149

[mobile-common]:https://github.com/aelassas/bookcars/blob/85dfa2f79e7609d18c6fe962aa4c21e625bcbb8a/mobile/lang/en.ts#L63

