### PR TITLE
Hotfix email links

### DIFF
--- a/api/src/controllers/bookingController.ts
+++ b/api/src/controllers/bookingController.ts
@@ -80,6 +80,7 @@ export const notify = async (driver: env.User, bookingId: string, user: env.User
   }
 
   // mail
+  const notificationURL = helper.joinURL(env.BACKEND_HOST, `update-booking?b=${bookingId}`);
   if (user.enableEmailNotifications) {
     const mailOptions: nodemailer.SendMailOptions = {
       from: env.SMTP_FROM,
@@ -88,7 +89,7 @@ export const notify = async (driver: env.User, bookingId: string, user: env.User
       html: `<p>
     ${i18n.t('HELLO')}${user.fullName},<br><br>
     ${message}<br><br>
-    ${helper.joinURL(env.BACKEND_HOST, `update-booking?b=${bookingId}`)}<br><br>
+    <a href="${notificationURL}">${notificationURL}</a><br><br>
     ${i18n.t('REGARDS')}<br>
     </p>`,
     }
@@ -229,6 +230,7 @@ export const checkout = async (req: Request, res: Response) => {
 
       i18n.locale = user.language
 
+      const activationURL = `${helper.joinURL(env.FRONTEND_HOST, 'activate')}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}`;
       const mailOptions: nodemailer.SendMailOptions = {
         from: env.SMTP_FROM,
         to: user.email,
@@ -236,7 +238,7 @@ export const checkout = async (req: Request, res: Response) => {
         html: `<p>
         ${i18n.t('HELLO')}${user.fullName},<br><br>
         ${i18n.t('ACCOUNT_ACTIVATION_LINK')}<br><br>
-        ${helper.joinURL(env.FRONTEND_HOST, 'activate')}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}<br><br>
+        <a href="${activationURL}">${activationURL}</a><br><br>
         ${i18n.t('REGARDS')}<br>
         </p>`,
       }
@@ -338,6 +340,7 @@ const notifyDriver = async (booking: env.Booking) => {
   }
 
   // mail
+  const notificationURL = helper.joinURL(env.FRONTEND_HOST, `booking?b=${booking._id}`)
   if (driver.enableEmailNotifications) {
     const mailOptions: nodemailer.SendMailOptions = {
       from: env.SMTP_FROM,
@@ -346,7 +349,7 @@ const notifyDriver = async (booking: env.Booking) => {
       html: `<p>
     ${i18n.t('HELLO')}${driver.fullName},<br><br>
     ${message}<br><br>
-    ${helper.joinURL(env.FRONTEND_HOST, `booking?b=${booking._id}`)}<br><br>
+    <a href="${notificationURL}">${notificationURL}</a><br><br>
     ${i18n.t('REGARDS')}<br>
     </p>`,
     }

--- a/api/src/controllers/userController.ts
+++ b/api/src/controllers/userController.ts
@@ -94,6 +94,7 @@ const _signup = async (req: Request, res: Response, userType: bookcarsTypes.User
     // Send email
     i18n.locale = user.language
 
+    const activationURL = `http${env.HTTPS ? 's' : ''}://${req.headers.host}/api/confirm-email/${user.email}/${token.token}`
     const mailOptions: nodemailer.SendMailOptions = {
       from: env.SMTP_FROM,
       to: user.email,
@@ -102,7 +103,7 @@ const _signup = async (req: Request, res: Response, userType: bookcarsTypes.User
         `<p>
     ${i18n.t('HELLO')}${user.fullName},<br><br>
     ${i18n.t('ACCOUNT_ACTIVATION_LINK')}<br><br>
-    http${env.HTTPS ? 's' : ''}://${req.headers.host}/api/confirm-email/${user.email}/${token.token}<br><br>
+    <a href="${activationURL}">${activationURL}</a><br><br>
     ${i18n.t('REGARDS')}<br>
     </p>`,
     }
@@ -196,6 +197,7 @@ export const create = async (req: Request, res: Response) => {
     // Send email
     i18n.locale = user.language
 
+    const activationURL = `${helper.joinURL(user.type === bookcarsTypes.UserType.User ? env.FRONTEND_HOST : env.BACKEND_HOST,'activate')}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}`
     const mailOptions: nodemailer.SendMailOptions = {
       from: env.SMTP_FROM,
       to: user.email,
@@ -204,10 +206,7 @@ export const create = async (req: Request, res: Response) => {
         `<p>
         ${i18n.t('HELLO')}${user.fullName},<br><br>
         ${i18n.t('ACCOUNT_ACTIVATION_LINK')}<br><br>
-        ${helper.joinURL(
-          user.type === bookcarsTypes.UserType.User ? env.FRONTEND_HOST : env.BACKEND_HOST,
-          'activate',
-        )}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}<br><br>
+        <a href=${activationURL}>${activationURL}</a><br><br>
         ${i18n.t('REGARDS')}<br>
         </p>`,
     }
@@ -337,6 +336,7 @@ export const resend = async (req: Request, res: Response) => {
 
       const reset = req.params.reset === 'true'
 
+      const resetPasswordURL = `${helper.joinURL(user.type === bookcarsTypes.UserType.User ? env.FRONTEND_HOST : env.BACKEND_HOST, reset ? 'reset-password' : 'activate')}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}`
       const mailOptions: nodemailer.SendMailOptions = {
         from: env.SMTP_FROM,
         to: user.email,
@@ -345,10 +345,7 @@ export const resend = async (req: Request, res: Response) => {
           `<p>
           ${i18n.t('HELLO')}${user.fullName},<br><br>  
           ${reset ? i18n.t('PASSWORD_RESET_LINK') : i18n.t('ACCOUNT_ACTIVATION_LINK')}<br><br>  
-          ${helper.joinURL(
-            user.type === bookcarsTypes.UserType.User ? env.FRONTEND_HOST : env.BACKEND_HOST,
-            reset ? 'reset-password' : 'activate',
-          )}/?u=${encodeURIComponent(user.id)}&e=${encodeURIComponent(user.email)}&t=${encodeURIComponent(token.token)}<br><br>
+          <a href=${resetPasswordURL}>${resetPasswordURL}</a><br><br>
           ${i18n.t('REGARDS')}<br>
           </p>`,
       }
@@ -755,6 +752,7 @@ export const resendLink = async (req: Request, res: Response) => {
 
     // Send email
     i18n.locale = user.language
+    const activationURL = `http${env.HTTPS ? 's' : ''}://${req.headers.host}/api/confirm-email/${user.email}/${token.token}`
     const mailOptions: nodemailer.SendMailOptions = {
       from: env.SMTP_FROM,
       to: user.email,
@@ -763,7 +761,7 @@ export const resendLink = async (req: Request, res: Response) => {
         `<p>
         ${i18n.t('HELLO')}${user.fullName},<br><br>
         ${i18n.t('ACCOUNT_ACTIVATION_LINK')}<br><br>
-        http${env.HTTPS ? 's' : ''}://${req.headers.host}/api/confirm-email/${user.email}/${token.token}<br><br>
+        <a href="${activationURL}">${activationURL}</a><br><br>
         ${i18n.t('REGARDS')}<br>
         </p>`,
     }


### PR DESCRIPTION
## Description
This change fixes formatting for links sent within emails, allowing for easier automation and better accessibility.

It does so in two ways:

- Keeps [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) that construct URLs on one line to avoid unexpected line breaks
- Wraps existing URLs within a HTML anchor element with a corresponding `href` attribute, allowing the link to be clicked from within the MailHog interface.

<details>
  <summary>Preview Image (Expand)</summary>
  <img src="https://github.com/user-attachments/assets/0aee3e0c-6dd8-42cb-b9ec-96a19ee82ec2" />
</details>

## Maintenance
If any upstream conflicts occur, you should always prefer their changes and then reimplement this fix afterwards if necessary.